### PR TITLE
FIX: 웹세션과, 웹소켓 ID간 버그 수정

### DIFF
--- a/.github/workflows/dockerhub_push.yml
+++ b/.github/workflows/dockerhub_push.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           context: .
           file: ./src/gateway/Dockerfile
-          tags: jhkimdocker/jcopy-gateway:v0.0.6
+          tags: jhkimdocker/jcopy-gateway:v0.0.7
           push: true
 
       - name: room test
@@ -32,7 +32,7 @@ jobs:
           context: .
           file: ./src/room/Dockerfile
           tags: jhkimdocker/jcopy-room:v0.0.6
-          push: true
+          push: false
 
       - name: storage Test
         uses: docker/build-push-action@v2
@@ -40,4 +40,4 @@ jobs:
           context: .
           file: ./src/storage/Dockerfile
           tags: jhkimdocker/jcopy-storage:v0.0.6
-          push: true
+          push: false

--- a/src/gateway/gateway.js
+++ b/src/gateway/gateway.js
@@ -176,6 +176,7 @@ Express.post("/room", (req, res) => {
         clientSession: req.session.id,
         expireTime: req.session.cookie._expires,
     };
+
     logger.debug(`gRPC Send CreateRoomRequest : ${JSON.stringify(CreateRoomRequest)}`);
 
     gRPCRoomServiceClient.CreateRoom(CreateRoomRequest, (error, CreateRoomResponse) => {
@@ -278,8 +279,7 @@ WSServer.on("connection", async (ws, request) => {
     for (const header of request.headers.cookie.split(';')) {
         if (header.includes("connect.sid")) {
             const session = header.replace("connect.sid=s%3A", "").split(".")[0];
-            ws.id = JSON.parse(await redisClient.v4.get(`sess:${session}`)).wsID;
-            connectedWebsockets[ws.id] = ws;
+            connectedWebsockets[session] = ws;
         }
     }
     logger.info(`WebSocket [${ws.id}] connected!!`);


### PR DESCRIPTION
현재 웹세션ID를 웹소캣 ID로 사용.
웹세션 ID를 redis에서 가져오는 과정에서 버그 발생
아마 웹소캣 연결시 redis에 웹세션 정보가 아직 반영되지 않아서 그런듯

이부분을 redis에서 웹세션을 가져오는것이 아닌
웹세션 자체 패킷 헤더에서 가져오는것으로 수정